### PR TITLE
Update the link appmesh-baseline.yml

### DIFF
--- a/copycommnads.txt
+++ b/copycommnads.txt
@@ -59,7 +59,7 @@ git clone https://github.com/brentley/ecsdemo-crystal.git
 
 7.
 cd ~/environment
-curl -s https://raw.githubusercontent.com/brentley/appmeshworkshop/master/templates/appmesh-baseline.yml -o appmesh-baseline.yml
+curl -s https://raw.githubusercontent.com/aws-containers/appmeshworkshop/main/templates/appmesh-baseline.yml -o appmesh-baseline.yml
 
 8.
 # Define environment variable


### PR DESCRIPTION
This PR changes the link to  the proper repository which is fixed the above issue.

Existing link of appmesh-baseline.yml has been archived. (https://github.com/brentley/appmeshworkshop)
Seems to be moved to https://github.com/aws-containers/appmeshworkshop as a master repository of the handson.
Also existing code has some issues as https://github.com/aws-containers/appmeshworkshop/pull/19 .

Thank you for providing the great handson!